### PR TITLE
SCSS(Sassy CSS) is a syntax for Sass and should be "Sass."

### DIFF
--- a/ux/WebFrontEndStack.json
+++ b/ux/WebFrontEndStack.json
@@ -444,14 +444,12 @@
     }, {
         "name": "CSS Pre-processors",
         "children": [{
-            "name": "SCSS"
-        }, {
             "name": "LESS",
             "children": [{
                 "name": "Hat"
             }]
         }, {
-            "name": "SASS",
+            "name": "Sass(SCSS)",
             "children": [{
                 "name": "Compass"
             }, {


### PR DESCRIPTION
Lemme know if you want this edited :)

Reference:

https://twitter.com/hcatlin/status/394555738636296192
http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax
