### PR TITLE
Update to URLs for JavaScript and HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ https://rawgit.com/unruledboy/WebFrontEndStack/master/ux/WebFrontEndStack.htm
 			- XML
 	- Core Concepts
 		- HTML
-			- DOM
-			- Element
+			- [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
+			- [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element)
 			- Attribute
 		- JavaScript
-			- Prototype
-			- Scope
-			- Closure
-			- JSON (JavaSript Object Notation)
-			- AJAX (Asynchronous JavaScript and XML)
+			- [Prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype)
+			- [Scope](https://developer.mozilla.org/en-US/docs/Glossary/Scope)
+			- [Closure](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures)
+			- [JSON (JavaSript Object Notation)](https://developer.mozilla.org/en-US/docs/Glossary/JSON)
+			- [AJAX (Asynchronous JavaScript and XML)](https://developer.mozilla.org/en-US/docs/AJAX)
 		- CSS
 			- Selector
 			- Priority

--- a/ux/WebFrontEndStack.json
+++ b/ux/WebFrontEndStack.json
@@ -83,24 +83,31 @@
         "children": [{
             "name": "HTML",
             "children": [{
-                "name": "DOM"
+                "name": "DOM",
+                "url": "https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model"
             }, {
-                "name": "Element"
+                "name": "Element",
+                "url": "https://developer.mozilla.org/en-US/docs/Web/API/Element"
             }, {
                 "name": "Attribute"
             }]
         }, {
             "name": "JavaScript",
             "children": [{
-                "name": "Prototype"
+                "name": "Prototype",
+                "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype"
             }, {
-                "name": "Scope"
+                "name": "Scope",
+                "url": "https://developer.mozilla.org/en-US/docs/Glossary/Scope"
             }, {
-                "name": "Closure"
+                "name": "Closure",
+                "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures"
             }, {
-                "name": "JSON (JavaSript Object Notation)"
+                "name": "JSON (JavaSript Object Notation)",
+                "url": "https://developer.mozilla.org/en-US/docs/Glossary/JSON"
             }, {
-                "name": "AJAX (Asynchronous JavaScript and XML)"
+                "name": "AJAX (Asynchronous JavaScript and XML)",
+                "url": "https://developer.mozilla.org/en-US/docs/AJAX"
             }]
         }, {
             "name": "CSS",


### PR DESCRIPTION
Using MDN for the references, lemme know if we should use W3C instead.
