### PR TITLE
Change Nitro to JavaScriptCore

### DIFF
--- a/ux/WebFrontEndStack.json
+++ b/ux/WebFrontEndStack.json
@@ -220,7 +220,7 @@
 			"name": "SpiderMonkey (Firefox)",
 			"url": " https://developer.mozilla.org/en-us/docs/Mozilla/Projects/SpiderMonkey"
 		}, {
-			"name": "Nitro (Safari)",
+			"name": "JavaScriptCore (Safari)",
 			"url": "https://en.wikipedia.org/wiki/WebKit#JavaScriptCore"
 		}]
 	}, {


### PR DESCRIPTION
Nitro is only a marketed name of JavaScriptCore, which is better known.
